### PR TITLE
Add basic trainer interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+pubspec.lock
+build/
+
+# Visual Studio Code
+.vscode/
+
+# Others
+ios/
+android/

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ lib
 │   │   └── workout_plan.dart
 │   ├── trainer
 │   │   ├── manage_students.dart
-│   │   └── create_workout.dart
+│   │   ├── create_workout.dart
+│   │   └── trainer_home.dart
 ├── models
 │   ├── user.dart
 │   ├── meal.dart

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'screens/trainer/trainer_home.dart';
+
+void main() {
+  runApp(const FitnessApp());
+}
+
+class FitnessApp extends StatelessWidget {
+  const FitnessApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Fitness Insight',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const TrainerHomeScreen(),
+    );
+  }
+}

--- a/lib/models/meal.dart
+++ b/lib/models/meal.dart
@@ -1,0 +1,7 @@
+class Meal {
+  final String id;
+  final String description;
+  final int calories;
+
+  Meal({required this.id, required this.description, required this.calories});
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,6 @@
+class User {
+  final String id;
+  final String name;
+
+  User({required this.id, required this.name});
+}

--- a/lib/models/workout.dart
+++ b/lib/models/workout.dart
@@ -1,0 +1,7 @@
+class Workout {
+  final String id;
+  final String name;
+  final int duration;
+
+  Workout({required this.id, required this.name, required this.duration});
+}

--- a/lib/screens/student/diet_tracker.dart
+++ b/lib/screens/student/diet_tracker.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class DietTrackerScreen extends StatelessWidget {
+  const DietTrackerScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('飲食記錄')),
+      body: const Center(child: Text('Diet Tracker Placeholder')),
+    );
+  }
+}

--- a/lib/screens/student/workout_plan.dart
+++ b/lib/screens/student/workout_plan.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class WorkoutPlanScreen extends StatelessWidget {
+  const WorkoutPlanScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('運動計劃')),
+      body: const Center(child: Text('Workout Plan Placeholder')),
+    );
+  }
+}

--- a/lib/screens/trainer/create_workout.dart
+++ b/lib/screens/trainer/create_workout.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class CreateWorkoutScreen extends StatefulWidget {
+  const CreateWorkoutScreen({Key? key}) : super(key: key);
+
+  @override
+  State<CreateWorkoutScreen> createState() => _CreateWorkoutScreenState();
+}
+
+class _CreateWorkoutScreenState extends State<CreateWorkoutScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _durationController = TextEditingController();
+
+  void _submit() {
+    final name = _nameController.text.trim();
+    final duration = int.tryParse(_durationController.text) ?? 0;
+    if (name.isEmpty || duration <= 0) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('訓練已建立：$name ($duration 分鐘)')),
+    );
+    _nameController.clear();
+    _durationController.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('建立訓練')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: '訓練名稱'),
+            ),
+            TextField(
+              controller: _durationController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '分鐘數'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _submit,
+              child: const Text('儲存'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/trainer/manage_students.dart
+++ b/lib/screens/trainer/manage_students.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import '../../models/user.dart';
+
+class ManageStudentsScreen extends StatefulWidget {
+  const ManageStudentsScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ManageStudentsScreen> createState() => _ManageStudentsScreenState();
+}
+
+class _ManageStudentsScreenState extends State<ManageStudentsScreen> {
+  final List<User> _students = [
+    User(id: '1', name: 'Alex'),
+    User(id: '2', name: 'Bella'),
+  ];
+  final TextEditingController _controller = TextEditingController();
+
+  void _addStudent() {
+    final name = _controller.text.trim();
+    if (name.isEmpty) return;
+    setState(() {
+      _students.add(User(id: DateTime.now().toIso8601String(), name: name));
+      _controller.clear();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('學員管理')),
+      body: ListView.builder(
+        itemCount: _students.length,
+        itemBuilder: (context, index) {
+          final user = _students[index];
+          return ListTile(
+            leading: const Icon(Icons.person),
+            title: Text(user.name),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          showDialog(
+            context: context,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text('新增學員'),
+                content: TextField(
+                  controller: _controller,
+                  decoration: const InputDecoration(labelText: '姓名'),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('取消'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      _addStudent();
+                      Navigator.pop(context);
+                    },
+                    child: const Text('新增'),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/screens/trainer/trainer_home.dart
+++ b/lib/screens/trainer/trainer_home.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'create_workout.dart';
+import 'manage_students.dart';
+
+class TrainerHomeScreen extends StatefulWidget {
+  const TrainerHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  State<TrainerHomeScreen> createState() => _TrainerHomeScreenState();
+}
+
+class _TrainerHomeScreenState extends State<TrainerHomeScreen> {
+  int _index = 0;
+  final List<Widget> _screens = const [
+    ManageStudentsScreen(),
+    CreateWorkoutScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _screens[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.people),
+            label: '學員管理',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.fitness_center),
+            label: '建立訓練',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,0 +1,6 @@
+class AIService {
+  Future<String> analyzeMeal(String imagePath) async {
+    // TODO: integrate with ML Kit
+    return '0 kcal';
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,0 +1,5 @@
+class ApiService {
+  Future<void> fetchData() async {
+    // TODO: implement API calls
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,9 @@
+class AuthService {
+  Future<void> login(String email, String password) async {
+    // TODO: implement authentication logic
+  }
+
+  Future<void> logout() async {
+    // TODO: implement logout logic
+  }
+}

--- a/lib/widgets/custom_card.dart
+++ b/lib/widgets/custom_card.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class CustomCard extends StatelessWidget {
+  final Widget child;
+  const CustomCard({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.all(8.0),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/widgets/progress_chart.dart
+++ b/lib/widgets/progress_chart.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class ProgressChart extends StatelessWidget {
+  final double progress;
+  const ProgressChart({Key? key, required this.progress}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 100,
+      child: Center(child: Text('Progress: ${progress.toStringAsFixed(1)}%')),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,16 @@
+name: fitness_insight
+description: A cross-platform fitness tracking app.
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/


### PR DESCRIPTION
## Summary
- add a `TrainerHomeScreen` with bottom navigation for trainer features
- implement `ManageStudentsScreen` to show and add sample students
- implement `CreateWorkoutScreen` with simple form
- update `main.dart` to start at trainer home
- document trainer_home.dart in the project structure

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*