### PR TITLE
加入基本 API 與 AI 整合範例

### DIFF
--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,6 +1,27 @@
+import 'dart:math';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
 class AIService {
+  final TextRecognizer _recognizer =
+      TextRecognizer(script: TextRecognitionScript.latin);
+
   Future<String> analyzeMeal(String imagePath) async {
-    // TODO: integrate with ML Kit
-    return '0 kcal';
+    try {
+      final inputImage = InputImage.fromFilePath(imagePath);
+      final recognizedText = await _recognizer.processImage(inputImage);
+      final match = RegExp(r'(\d+)\s*k?cal', caseSensitive: false)
+          .firstMatch(recognizedText.text);
+      if (match != null) {
+        return '${match.group(1)} kcal';
+      }
+    } catch (_) {
+      // If ML Kit initialization fails, fall back to a fake result.
+    }
+    final randomCalories = Random(imagePath.hashCode).nextInt(500) + 50;
+    return '${randomCalories} kcal';
+  }
+
+  void dispose() {
+    _recognizer.close();
   }
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,4 +1,3 @@
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../models/meal.dart';
@@ -26,6 +25,20 @@ class ApiService {
       'description': meal.description,
       'calories': meal.calories,
     });
+  }
 
+  Future<Meal?> fetchMeal(String userId, String mealId) async {
+    final doc = await _db
+        .collection('users')
+        .doc(userId)
+        .collection('meals')
+        .doc(mealId)
+        .get();
+    if (!doc.exists) return null;
+    return Meal(
+      id: doc.id,
+      description: doc['description'] as String,
+      calories: doc['calories'] as int,
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   firebase_core: ^2.13.0
   firebase_auth: ^4.6.2
   cloud_firestore: ^4.8.2
+  google_mlkit_text_recognition: ^0.10.0
 
 
 flutter:


### PR DESCRIPTION
## Summary
- 新增 `fetchMeal` 方法示範從後端取得單筆餐點資料
- `AIService` 更新：加入 ML Kit 使用範例並在失敗時提供隨機假資料
- 更新 `pubspec.yaml` 加入 `google_mlkit_text_recognition`

## Testing
- No tests provided
- `dart`/`flutter` not installed in container