### PR TITLE
新增登入與註冊畫面，實作 Firebase 認證

### DIFF
--- a/lib/screens/auth/login.dart
+++ b/lib/screens/auth/login.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatelessWidget {
+  LoginScreen({super.key});
+
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: '密碼'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                // TODO: Add login logic
+              },
+              child: const Text('提交'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/auth/register.dart
+++ b/lib/screens/auth/register.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class RegisterScreen extends StatelessWidget {
+  RegisterScreen({super.key});
+
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: '密碼'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                // TODO: Add registration logic
+              },
+              child: const Text('提交'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,6 +1,23 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
 class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
   Future<bool> signIn(String email, String password) async {
-    // TODO: implement authentication logic
-    return true;
+    try {
+      await _auth.signInWithEmailAndPassword(email: email, password: password);
+      return true;
+    } on FirebaseAuthException {
+      return false;
+    }
+  }
+
+  Future<bool> signUp(String email, String password) async {
+    try {
+      await _auth.createUserWithEmailAndPassword(email: email, password: password);
+      return true;
+    } on FirebaseAuthException {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## 主要變更
- 新增 `lib/screens/auth/login.dart` 與 `register.dart`，提供輸入 Email、密碼與提交按鈕的 `StatelessWidget`。
- `auth_service.dart` 新增 FirebaseAuth 整合，實作 `signIn` 及 `signUp` 方法。

## 測試
- 無可用的 dart/flutter 執行環境，未能執行 `flutter analyze` 或 `flutter test`。